### PR TITLE
Launch uneven-split with python2 only

### DIFF
--- a/clone-detector/execute.sh
+++ b/clone-detector/execute.sh
@@ -12,7 +12,7 @@ num_nodes="${1:-2}"
 th="${2:-8}"
 queryfile="$rootPATH/input/dataset/blocks.file"
 echo "spliting query file $queryfile into $num_nodes parts"
-python $rootPATH/unevensplit.py $queryfile $num_nodes
+python2 $rootPATH/unevensplit.py $queryfile $num_nodes
 echo "moving files"
 bash $rootPATH/preparequery.sh $num_nodes
 echo "done!"


### PR DESCRIPTION
On some machines python command is equivalent to python3, not python2, which results in runtime errors